### PR TITLE
fix: scan for [Might of the Scourge] when calculating Ranged Crit Chance

### DIFF
--- a/Localization.lua
+++ b/Localization.lua
@@ -69,6 +69,9 @@ BCS["L"] = {
 	["^%+(%d+) Healing Spells"] = "^%+(%d+) Healing Spells",
 	["^%+(%d+) Spell Damage and Healing"] = "^%+(%d+) Spell Damage and Healing",
 
+	-- sapphiron shoulder enchants
+	["%+(%d+)%% Critical Strike"] = "%+(%d+)%% Critical Strike",
+	
 	["Equip: Increases damage and healing done by magical spells and effects by up to (%d+)."] = "Equip: Increases damage and healing done by magical spells and effects by up to (%d+).",
 	["Equip: Increases healing done by spells and effects by up to (%d+)."] = "Equip: Increases healing done by spells and effects by up to (%d+).",
 

--- a/helper.lua
+++ b/helper.lua
@@ -495,6 +495,11 @@ function BCS:GetRangedCritChance()
 						if value then
 							BCScache["gear"].ranged_crit = BCScache["gear"].ranged_crit + tonumber(value)
 						end
+						-- check for Might of the Scourge enchant
+						_,_, value = strfind(left:GetText(), L["%+(%d+)%% Critical Strike"])
+						if value then
+							BCScache["gear"].ranged_crit = BCScache["gear"].ranged_crit + tonumber(value)
+						end
 
 						_,_, value = strfind(left:GetText(), "(.+) %(%d/%d%)")
 						if value then


### PR DESCRIPTION
I noticed the +1% crit from Might of the Scourge was not getting added to my ranged crit chance. This is because the enchant has a unique tooltip text, like ZG enchants do. This patch fixes that.

Tooltip:
![image](https://github.com/user-attachments/assets/bb8ff794-0a15-4ca1-8586-115a6a5c38c0)


Before:
![image](https://github.com/user-attachments/assets/37109288-1a23-472e-8a25-43cf556e0ac5)


After:
![image](https://github.com/user-attachments/assets/e74b906e-890e-451d-b7d7-60bad1b0571c)
