### PR TITLE
Remove toughness from Iron Clad calculation

### DIFF
--- a/Localization.lua
+++ b/Localization.lua
@@ -129,6 +129,7 @@ BCS["L"] = {
 	["Increases your healing power by (%d+)%% of your Armor."] = "Increases your healing power by (%d+)%% of your Armor.",
 	["Increases the critical effect chance of your Holy Light and Flash of Light by (%d+)%%."] = "Increases the critical effect chance of your Holy Light and Flash of Light by (%d+)%%.",
 	["Improves your chance to get a critical strike with Holy Shock by (%d+)%%."] = "Improves your chance to get a critical strike with Holy Shock by (%d+)%%.",
+	["Increases your armor value from items by (%d+)%%."] = "Increases your armor value from items by (%d+)%%.",
 	-- shaman
 	["Increases the critical strike chance of your Lightning Bolt and Chain Lightning spells by an additional (%d+)%%."] = "Increases the critical strike chance of your Lightning Bolt and Chain Lightning spells by an additional (%d+)%%.",
 	["Increases the critical effect chance of your healing and lightning spells by (%d+)%%."] = "Increases the critical effect chance of your healing and lightning spells by (%d+)%%.",

--- a/helper.lua
+++ b/helper.lua
@@ -1438,6 +1438,7 @@ function BCS:GetSpellPower(school)
 end
 
 local ironClad = nil
+local toughness = nil
 --this is stuff that gives ONLY healing, we count stuff that gives both damage and healing in GetSpellPower
 function BCS:GetHealingPower()
 	local healPower = 0;
@@ -1445,6 +1446,7 @@ function BCS:GetHealingPower()
 	--talents
 	if BCS.needScanTalents then
 		ironClad = nil
+		toughness = nil
 		BCScache["talents"].healing = 0
 		for tab=1, GetNumTalentTabs() do
 			for talent=1, GetNumTalents(tab) do
@@ -1458,6 +1460,13 @@ function BCS:GetHealingPower()
 						local _,_, value = strfind(text, L["Increases your healing power by (%d+)%% of your Armor."])
 						if value and rank > 0 then
 							ironClad = tonumber(value)
+							break
+						end
+						-- Paladin
+						-- Toughness
+						local _,_, value = strfind(text, L["Increases your armor value from items by (%d+)%%."])
+						if value and rank > 0 then
+							toughness = tonumber(value)
 							break
 						end
 					end
@@ -1580,6 +1589,10 @@ function BCS:GetHealingPower()
 		local base = UnitArmor("player")
 		local _, agility = UnitStat("player", 2)
 		local armorFromGear = base - (agility * 2)
+		-- Iron Clad is calculate on raw armor without toughness bonus, base armor includes the bonus
+		if toughness ~= nil then
+			armorFromGear = armorFromGear / (1 + toughness/100)
+		end
 		BCScache["talents"].healing = floor(((ironClad / 100) * armorFromGear))
 	end
 	healPower = BCScache["gear"].healing + BCScache["auras"].healing + BCScache["talents"].healing


### PR DESCRIPTION
The UnitArmor("player") base value includes the armor value from items after the Toughness talent is applied. In testing it showed that the Iron Clad bonus is calculated on the base armor values without Toughness. I added scanning for that talent and remove the Toughness bonus for Iron Clad to be closer to the actual values.