### PR TITLE
Fix incorrect variable in SendAddonMessage call

### DIFF
--- a/BetterCharacterStats.lua
+++ b/BetterCharacterStats.lua
@@ -140,7 +140,7 @@ function BCS:OnEvent()
 		if not hasTreeAura then
 			aura = 0
         else
-            SendAddonMessage("bcs", "TREE"..","..player, "PARTY")
+            SendAddonMessage("bcs", "TREE"..","..playerName, "PARTY")
             --BCS:Print("sent tree request")
 		end
 		if PaperDollFrame:IsVisible() then


### PR DESCRIPTION
Replaced `player` with `playerName` to ensure the correct value is sent in the addon message. This resolves potential issues with message accuracy in party communication.