### PR TITLE
fix priest crit

### DIFF
--- a/BetterCharacterStats.lua
+++ b/BetterCharacterStats.lua
@@ -992,7 +992,6 @@ function BCS:SetSpellCritChance(statFrame)
 				else
 					GameTooltip:AddLine(format(L.CRIT_OFFENCE, total3))
 				end
-				GameTooltip:AddLine(format("Smite: %.2f%%", total4))
 			end
 			if spell4 > 0 then
 				GameTooltip:AddLine(format(L.CRIT_PRAYER, total4 + spell1))


### PR DESCRIPTION
Smite doesn't need its own line and the number is wrong, I think it's removed in an earlier commit but slipped back somehow.